### PR TITLE
add render item to user data during sorting

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -100,7 +100,7 @@ function WebGLRenderList() {
 
 		renderItemsIndex ++;
 
-		object.userData.renderItem = renderItem;
+		if ( object.userData ) object.userData.renderItem = renderItem;
 
 		return renderItem;
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -100,6 +100,8 @@ function WebGLRenderList() {
 
 		renderItemsIndex ++;
 
+		object.userData.renderItem = renderItem;
+
 		return renderItem;
 
 	}


### PR DESCRIPTION
## Context

To support custom UI sorting, we need to be able to access the sort params of other UI objects in the comparator.

## Testing

working with this passed into `renderer.setTransparentSort()`:

```ts
// based on https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLRenderLists.js#L27
function reversePainterSortWithUi(a: RenderListItem, b: RenderListItem) {
  // note(owenmech): to group UI elements together, sort them as if they were their root.
  const rootA = a.object.userData?.rootUi?.frame?.userData?.renderItem
  const rootB = b.object.userData?.rootUi?.frame?.userData?.renderItem
  a.z = rootA?.z ?? a.z
  b.z = rootB?.z ?? b.z

  if (a.groupOrder !== b.groupOrder) {
    return a.groupOrder - b.groupOrder
  } else if (a.renderOrder !== b.renderOrder) {
    return a.renderOrder - b.renderOrder
  } else if (rootA && rootA.id === rootB?.id) {
    // note(owenmech): when UI elements are in the same family, apply the custom UI sorting
    const aUiOrder = a.object.userData.uiOrder ?? 0
    const bUiOrder = b.object.userData.uiOrder ?? 0
    if (aUiOrder !== bUiOrder) {
      return aUiOrder - bUiOrder
    } else if (a.object.userData.isText !== b.object.userData.isText) {
      return a.object.userData.isText ? 1 : -1
    } else {
      return a.id - b.id
    }
  } else if (a.z !== b.z) {
    return b.z - a.z
  } else if (rootA?.id !== rootB?.id) {
    // note(owenmech): if two UI elements have different root UIs which happen to have the same Z
    // (or one is UI and one isn't), we must break the tie the same way the roots themselves would
    // to ensure that UI families are grouped together, as IDs are more-or-less arbitrary.
    return (rootA?.id ?? a.id) - (rootB?.id ?? b.id)
  } else {
    return a.id - b.id
  }
}
```
