### PR TITLE
add item map to renderlist

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -56,7 +56,7 @@ function WebGLRenderList() {
 	const transmissive = [];
 	const transparent = [];
 
-	let items = new WeakMap();
+	let objectIdToRenderItem = new WeakMap();
 
 	function init() {
 
@@ -66,7 +66,7 @@ function WebGLRenderList() {
 		transmissive.length = 0;
 		transparent.length = 0;
 
-		items = new WeakMap();
+		objectIdToRenderItem = new WeakMap();
 
 	}
 
@@ -126,7 +126,7 @@ function WebGLRenderList() {
 
 		}
 
-		items.set( object, renderItem );
+		objectIdToRenderItem.set( object, renderItem );
 
 	}
 
@@ -148,7 +148,7 @@ function WebGLRenderList() {
 
 		}
 
-		items.set( object, renderItem );
+		objectIdToRenderItem.set( object, renderItem );
 
 	}
 
@@ -186,7 +186,7 @@ function WebGLRenderList() {
 		transmissive: transmissive,
 		transparent: transparent,
 
-		items: items,
+		objectIdToRenderItem,
 
 		init: init,
 		push: push,

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -56,7 +56,7 @@ function WebGLRenderList() {
 	const transmissive = [];
 	const transparent = [];
 
-	let objectIdToRenderItem = new WeakMap();
+	let objectIdToRenderItem = new Map();
 
 	function init() {
 
@@ -66,7 +66,7 @@ function WebGLRenderList() {
 		transmissive.length = 0;
 		transparent.length = 0;
 
-		objectIdToRenderItem = new WeakMap();
+		objectIdToRenderItem.clear();
 
 	}
 
@@ -126,7 +126,7 @@ function WebGLRenderList() {
 
 		}
 
-		objectIdToRenderItem.set( object, renderItem );
+		objectIdToRenderItem.set( object.id, renderItem );
 
 	}
 
@@ -148,7 +148,7 @@ function WebGLRenderList() {
 
 		}
 
-		objectIdToRenderItem.set( object, renderItem );
+		objectIdToRenderItem.set( object.id, renderItem );
 
 	}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -56,6 +56,8 @@ function WebGLRenderList() {
 	const transmissive = [];
 	const transparent = [];
 
+	let items = new WeakMap();
+
 	function init() {
 
 		renderItemsIndex = 0;
@@ -63,6 +65,8 @@ function WebGLRenderList() {
 		opaque.length = 0;
 		transmissive.length = 0;
 		transparent.length = 0;
+
+		items = new WeakMap();
 
 	}
 
@@ -122,6 +126,8 @@ function WebGLRenderList() {
 
 		}
 
+		items.set( object, renderItem );
+
 	}
 
 	function unshift( object, geometry, material, groupOrder, z, group ) {
@@ -141,6 +147,8 @@ function WebGLRenderList() {
 			opaque.unshift( renderItem );
 
 		}
+
+		items.set( object, renderItem );
 
 	}
 
@@ -177,6 +185,8 @@ function WebGLRenderList() {
 		opaque: opaque,
 		transmissive: transmissive,
 		transparent: transparent,
+
+		items: items,
 
 		init: init,
 		push: push,

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -186,7 +186,7 @@ function WebGLRenderList() {
 		transmissive: transmissive,
 		transparent: transparent,
 
-		objectIdToRenderItem,
+		objectIdToRenderItem: objectIdToRenderItem,
 
 		init: init,
 		push: push,

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -56,7 +56,7 @@ function WebGLRenderList() {
 	const transmissive = [];
 	const transparent = [];
 
-	let objectIdToRenderItem = new Map();
+	const objectIdToRenderItem = new Map();
 
 	function init() {
 


### PR DESCRIPTION
## Context

Allows for a custom renderer sorting comparator to access the `RenderItem` properties of another object.

## Testing

Tested with https://github.com/8thwall/code8/pull/2037/files#diff-80068fa1d904387a335f350cdad391f11039e62aac3eca53fe38411a0175f022